### PR TITLE
Raise timeout exception if <4 bytes received

### DIFF
--- a/usbtmc/usbtmc.py
+++ b/usbtmc/usbtmc.py
@@ -655,6 +655,9 @@ class Instrument(object):
 
                 resp = self.bulk_in_ep.read(read_len+USBTMC_HEADER_SIZE+3, timeout=self._timeout_ms)
 
+                if len(resp) < 4:
+                    raise usb.core.USBError('Operation timed out', errno=110)
+
                 if sys.version_info >= (3, 2):
                     resp = resp.tobytes()
                 else:


### PR DESCRIPTION
Sometimes timeouts are not handled nicely, resulting in the following stacktrace:

> print self.dev.ask('*IDN?')
>   File "/usr/local/lib/python2.7/dist-packages/usbtmc/usbtmc.py", line 635, in ask
>     return self.read(num, encoding)
>   File "/usr/local/lib/python2.7/dist-packages/usbtmc/usbtmc.py", line 618, in read
>     return self.read_raw(num).decode(encoding).rstrip('\r\n')
>   File "/usr/local/lib/python2.7/dist-packages/usbtmc/usbtmc.py", line 547, in read_raw
>     msgid, btag, btaginverse, transfer_size, transfer_attributes, data = self.unpack_dev_dep_resp_header(resp)
>   File "/usr/local/lib/python2.7/dist-packages/usbtmc/usbtmc.py", line 468, in unpack_dev_dep_resp_header
>     msgid, btag, btaginverse = self.unpack_bulk_in_header(data)
>   File "/usr/local/lib/python2.7/dist-packages/usbtmc/usbtmc.py", line 464, in unpack_bulk_in_header
>     msgid, btag, btaginverse = struct.unpack_from('BBBx', data)
> error: unpack_from requires a buffer of at least 4 bytes
> 