### PR TITLE
Add Agilent U2751A 4x8 switch matrix

### DIFF
--- a/usbtmc/usbtmc.py
+++ b/usbtmc/usbtmc.py
@@ -136,9 +136,10 @@ def list_devices():
 
             if dev.idVendor == 0x0957:
                 # Agilent
-                if dev.idProduct in [0x2818, 0x4218, 0x4418]:
+                if dev.idProduct in [0x2818, 0x3E18, 0x4218, 0x4418]:
                     # Agilent U27xx modular devices in firmware update mode
                     # 0x2818 for U2701A/U2702A (firmware update mode on power up)
+                    # 0x3E18 for U2751A (firmware update mode on power up)
                     # 0x4218 for U2722A (firmware update mode on power up)
                     # 0x4418 for U2723A (firmware update mode on power up)
                     return True
@@ -165,10 +166,14 @@ def list_resources():
         if idVendor == 0x0957 and idProduct == 0x4218:
             # Agilent U2722A firmware update mode
             idProduct = 0x4118
-        
+
         if idVendor == 0x0957 and idProduct == 0x4418:
             # Agilent U2723A firmware update mode
             idProduct = 0x4318
+
+        if idVendor == 0x0957 and idProduct == 0x3E18:
+            # Agilent U2723A firmware update mode
+            idProduct = 0x3D18
 
         # attempt to read serial number
         iSerial = None
@@ -202,7 +207,7 @@ def find_device(idVendor=None, idProduct=None, iSerial=None):
             # Agilent U2701A/U2702A firmware update mode
             if dev.idVendor == idVendor and dev.idProduct == 0x2818:
                 found = True
-        
+
         if idVendor == 0x0957 and idProduct == 0x4118:
             # Agilent U2722A firmware update mode
             if dev.idVendor == idVendor and dev.idProduct == 0x4218:
@@ -211,6 +216,11 @@ def find_device(idVendor=None, idProduct=None, iSerial=None):
         if idVendor == 0x0957 and idProduct == 0x4318:
             # Agilent U2723A firmware update mode
             if dev.idVendor == idVendor and dev.idProduct == 0x4418:
+                found = True
+
+        if idVendor == 0x0957 and idProduct == 0x3D18:
+            # Agilent U2751A firmware update mode
+            if dev.idVendor == idVendor and dev.idProduct == 0x3E18:
                 found = True
 
         if not found:
@@ -354,25 +364,30 @@ class Instrument(object):
 
         # initialize device
 
-        if self.device.idVendor == 0x0957 and self.device.idProduct in [0x2818, 0x4218, 0x4418]:
+        if self.device.idVendor == 0x0957 and self.device.idProduct in [0x2818, 0x3E18, 0x4218, 0x4418]:
             # Agilent U27xx modular devices
-            # U2701A/U2702A, U2722A/U2723A
+            # U2701A/U2702A, U2722A/U2723A, U2751A
             # These devices require a short initialization sequence, presumably
             # to take them out of 'firmware update' mode after confirming
             # that the firmware version is correct. This is required once
             # on every power-on before the device can be used.
             # Note that the device will reset and the product ID will change.
             # U2701A/U2702A boot 0x2818, usbtmc 0x2918
+            # U2751A boot 0x3E18, usbtmc 0x3D18
             # U2722A boot 0x4218, usbtmc 0x4118
             # U2723A boot 0x4418, usbtmc 0x4318
- 
+
             serial = self.device.serial_number
 
             new_id = 0
 
-            if self.device.idProduct == 0x2818:
-                # U2701A/U2702A
-                new_id = 0x2918
+            if self.device.idProduct in [0x2818, 0x3E18]:
+                if self.device.idProduct == 0x2818:
+                    # U2701A/U2702A
+                    new_id = 0x2918
+                elif self.device.idProduct == 0x3E18:
+                    # U2751A
+                    new_id = 0x3D18
                 self.device.ctrl_transfer(bmRequestType=0xC0, bRequest=0x0C, wValue=0x0000, wIndex=0x047E, data_or_wLength=0x0001)
                 self.device.ctrl_transfer(bmRequestType=0xC0, bRequest=0x0C, wValue=0x0000, wIndex=0x047D, data_or_wLength=0x0006)
                 self.device.ctrl_transfer(bmRequestType=0xC0, bRequest=0x0C, wValue=0x0000, wIndex=0x0484, data_or_wLength=0x0005)
@@ -680,7 +695,7 @@ class Instrument(object):
                 if self.rigol_quirk and read_data:
                     pass # do nothing, the packet has no header if it isn't the first
                 else:
-                    msgid, btag, btaginverse, transfer_size, transfer_attributes, data = self.unpack_dev_dep_resp_header(resp) 
+                    msgid, btag, btaginverse, transfer_size, transfer_attributes, data = self.unpack_dev_dep_resp_header(resp)
 
 
                 if self.rigol_quirk:


### PR DESCRIPTION
Like other Agilent modular USB test equipment, the U2751A 4x8 switch matrix boots up into what appears to be a firmware update mode with a different product ID than after being initialized when it is in USBTMC mode.