### PR TITLE
Add an additional Rigol quirk to skip INITIATE_CLEAR

### DIFF
--- a/usbtmc/usbtmc.py
+++ b/usbtmc/usbtmc.py
@@ -487,7 +487,9 @@ class Instrument(object):
 
         self.connected = True
 
-        self.clear()
+        # DS1000Z (and DS2000, from eevblog forum) fails with INITIATE_CLEAR
+        if not self.rigol_quirk:
+            self.clear()
 
         self.get_capabilities()
 


### PR DESCRIPTION
Hi. This patch updates usbtmc.py quirk handling to make it work better with Rigol DS1000Z-series oscilloscope (and probably also with DS2000-series).

DS1000Z does not handle INITIATE_CLEAR well, and USB response just times out (and hangs) once it receives this message. INITIATE_CLEAR is a required command as per USBTMC spec, but Rigol's implementation is known to be broken in many parts.

There's a workaround to do `echo *IDN? > /dev/usbtmc<N>` to initialize the device without sending INITIATE_CLEAR, but that's Linux-specific and user has to figure out which /dev/usbtmc* device to use. This patch will make things much easier and portable. 

I have tested this patch with rigolcap.py script I pasted to gist:
https://gist.github.com/tai/408053a0955bf1712a5809240aa5544f

Also, just FYI, https://github.com/jtambasco/RigolOscilloscope.git which uses python-usbtmc works with Rigol, but has a following hack to make it work:

```python
os.system('echo *IDN? >> /dev/%s' % dev[3])
```

With this patch, user of usbtmc.py can now just do this:

```python
tmc = usbtmc.Instrument(0x1ab1, 0x04ce)
tmc.write_raw(b'*IDN?')
```
